### PR TITLE
chore: minor refactor of main.rs

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,4 @@
+// Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use reqwest::Client;


### PR DESCRIPTION
Got the updated chat GPT to refacor main.rs with some suggestions it made.

It seems to run without any issues so ... yay? 🤣 

![image](https://github.com/ai-qol-things/rusty-ollama/assets/862951/2352a1f1-6507-4551-8e80-bb667ffa2fbd)

---

Here is a summary of the changes made to the original main.rs file, which you can include in your pull request:

- Error Handling Enhancements: The custom ApiError enum was expanded to include more specific error cases, improving the granularity and readability of error handling within the application. Additionally, the From<ApiError> for tauri::InvokeError implementation was added to convert ApiError into tauri::InvokeError. This ensures that errors from our application are compatible with Tauri's error handling mechanism.

- Serialization Fixes: We removed the manual implementations of the Serialize trait for ApiError and ModelList since they were unnecessary. The derive(Serialize) attribute provides an out-of-the-box solution that is less error-prone and easier to maintain.

- Dependency Cleanup: Unused import std::process::Output was removed, clearing up the warnings and cleaning up the code.

- Error Conversion Update: Errors from the reqwest library and serde_json parsing that do not implement the Serialize trait are now converted to strings before being turned into tauri::InvokeError. This change was necessary because tauri::InvokeError requires contained errors to be serializable, which is not the case for reqwest::Error.

- Improved Command Handlers: The Tauri command handlers (greet, askollama, and get_ollama_models) were updated for clarity and conciseness. For instance, the greet function was simplified to directly return the formatted greeting string.

- Async/Await Syntax: The askollama command was refactored to use async/await syntax for making HTTP POST requests. This change modernizes the code and aligns with Rust's asynchronous programming model.

- Correct Trait Scopes: Necessary traits for serde_json::Error::custom were brought into scope to resolve the issue with the previous use of the custom function, which was incorrectly scoped.

- Code Comments and Documentation: Comments were added and updated to provide clarity on the functionality of the command handlers and the main function.

-  Code Formatting and Style: Throughout the changes, the code was formatted according to Rust's idiomatic style guidelines for better readability and maintainability.

These changes collectively improve the code's maintainability, readability, and compatibility with Tauri's framework, while also enhancing the error handling mechanism to provide more meaningful error messages to the end-users.