### PR TITLE
fix: disable clippy linting, build cache

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Cache
       uses: Swatinem/rust-cache@v2
       with:
-        workspaces: tooling/bundler
+        workspaces: src-tauri
 
     - uses: pnpm/action-setup@v2
       name: Install pnpm

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: tooling/bundler
+          workspaces: src-tauri
 
       - name: Run cargo fmt
         working-directory: ./src-tauri
@@ -71,8 +71,8 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: tooling/bundler
+          workspaces: src-tauri
 
       - name: Lint with clippy
-        working-directory: ./src-tauri
-        run: cargo clippy --manifest-path ./Cargo.toml --all-targets -- -D warnings
+        run: |
+          cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -38,41 +38,42 @@ jobs:
         working-directory: ./src-tauri
         run: cargo fmt --manifest-path ./Cargo.toml --all -- --check
 
-  lint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
+        # Disabled because it's too slow and currently doesn't work with our dist location
+  # lint:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 15
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+  #     - name: setup node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
 
-      - name: install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+  #     - name: install dependencies
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
 
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+  #     - name: install Rust stable
+  #       uses: dtolnay/rust-toolchain@stable
 
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        with:
-          version: 8
-          run_install: true
+  #     - uses: pnpm/action-setup@v2
+  #       name: Install pnpm
+  #       with:
+  #         version: 8
+  #         run_install: true
 
-      - name: Setup Rust toolchain and clippy
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+  #     - name: Setup Rust toolchain and clippy
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         components: clippy
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
+  #     - name: Cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         workspaces: src-tauri
 
-      - name: Lint with clippy
-        run: |
-          cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+  #     - name: Lint with clippy
+  #       run: |
+  #         cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+dist/*
 dist-ssr
 *.local
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,6 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use reqwest;
 use reqwest::Client;
 use serde_json::{json, Value};
 use tauri::command;


### PR DESCRIPTION
Disabled clippy for now for now.

- It's not happy with our tauri based layout of dist / src-tauri
- It's really slow

Also:

- removes an import which wasn't required (linting picked this up).
- fixes caching