### PR TITLE
Popup placeholder chat and settings windows from toolbar icon buttons

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Spotlight</title>
+    <title>Chat</title>
   </head>
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/windows/chat/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",
     "@tauri-apps/cli": "^1.5.0",
+    "@types/node": "^20.10.0",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@types/react-syntax-highlighter": "^15.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ devDependencies:
   '@tauri-apps/cli':
     specifier: ^1.5.0
     version: 1.5.0
+  '@types/node':
+    specifier: ^20.10.0
+    version: 20.10.0
   '@types/react':
     specifier: ^18.2.15
     version: 18.2.15
@@ -72,7 +75,7 @@ devDependencies:
     version: 5.0.2
   vite:
     specifier: ^4.4.4
-    version: 4.4.4
+    version: 4.4.4(@types/node@20.10.0)
 
 packages:
 
@@ -797,6 +800,12 @@ packages:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: false
 
+  /@types/node@20.10.0:
+    resolution: {integrity: sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
   /@types/prop-types@15.7.9:
     resolution: {integrity: sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==}
 
@@ -844,7 +853,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.23.2)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.2)
       react-refresh: 0.14.0
-      vite: 4.4.4
+      vite: 4.4.4(@types/node@20.10.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2336,6 +2345,10 @@ packages:
     hasBin: true
     dev: true
 
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
   /unified@11.0.4:
     resolution: {integrity: sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==}
     dependencies:
@@ -2418,7 +2431,7 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
-  /vite@4.4.4:
+  /vite@4.4.4(@types/node@20.10.0):
     resolution: {integrity: sha512-4mvsTxjkveWrKDJI70QmelfVqTm+ihFAb6+xf4sjEU2TmUCTlVX87tmg/QooPEMQb/lM9qGHT99ebqPziEd3wg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -2446,6 +2459,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.10.0
       esbuild: 0.18.20
       postcss: 8.4.31
       rollup: 3.29.4

--- a/settings.html
+++ b/settings.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Spotlight</title>
+    <title>Settings</title>
   </head>
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/windows/settings/main.tsx"></script>
   </body>
 </html>

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 // Import the command macro for Tauri.
 use serde::ser::Error as SerdeError;
 use serde::Serialize; // Add this to bring the `Error` trait into scope.
+use tauri::{Manager, Builder, WindowBuilder, WindowUrl};
 
 #[derive(Debug, Serialize)]
 struct ModelList {
@@ -90,16 +91,49 @@ fn get_ollama_models() -> Result<ModelList, ApiError> {
     Ok(ModelList { models })
 }
 
+
+#[tauri::command]
+fn open_chat_window(app: tauri::AppHandle) {
+    if app.get_window("chat").is_none() {
+        WindowBuilder::new(&app, "chat", WindowUrl::App("chat.html".into()))
+            .title("Chat")
+            .visible(false) // Start with window not visible
+            .build()
+            .expect("Failed to build window");
+    } else {
+        // Optionally, bring the existing window to the front
+        let window = app.get_window("chat").unwrap();
+        window.set_focus().unwrap();
+    }
+}
+
+#[tauri::command]
+fn open_settings_window(app: tauri::AppHandle) {
+    if app.get_window("settings").is_none() {
+        WindowBuilder::new(&app, "settings", WindowUrl::App("settings.html".into()))
+            .title("Settings")
+            .visible(false) // Start with window not visible
+            .build()
+            .expect("Failed to build window");
+    } else {
+        // Optionally, bring the existing window to the front
+        let window = app.get_window("settings").unwrap();
+        window.set_focus().unwrap();
+    }
+}
+
 mod spotlight;
 
 fn main() {
-    tauri::Builder::default()
+    Builder::default()
         .invoke_handler(tauri::generate_handler![
             spotlight::init_spotlight_window,
             spotlight::show_spotlight,
             spotlight::hide_spotlight,
             askollama,
-            get_ollama_models
+            get_ollama_models,
+            open_chat_window,
+            open_settings_window
         ])
         .manage(spotlight::State::default())
         .setup(move |app| {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 // Import the command macro for Tauri.
 use serde::ser::Error as SerdeError;
 use serde::Serialize; // Add this to bring the `Error` trait into scope.
-use tauri::{Manager, Builder, WindowBuilder, WindowUrl};
+use tauri::{Builder, Manager, WindowBuilder, WindowUrl};
 
 #[derive(Debug, Serialize)]
 struct ModelList {
@@ -90,7 +90,6 @@ fn get_ollama_models() -> Result<ModelList, ApiError> {
 
     Ok(ModelList { models })
 }
-
 
 #[tauri::command]
 fn open_chat_window(app: tauri::AppHandle) {

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import ModelSelect from './ModelSelect';
 import { AdjustmentsVerticalIcon, ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import {invoke} from "@tauri-apps/api/tauri";
 
 interface TopBarProps {
 }
 
 const TopBar: React.FC<TopBarProps> = () => {
+    const handleChatModeClicked = async () => {
+        await invoke<void>('open_chat_window');
+    }
+
+    const handleSettingsClicked = async () => {
+        await invoke<void>('open_settings_window');
+    }
     return (
         <div className="flex justify-between items-center p-5">
             <img src="/rllama.png" alt="Logo" className="h-9 w-9 rounded-full" />
@@ -16,13 +24,13 @@ const TopBar: React.FC<TopBarProps> = () => {
             </div>
             <div>
                 <button
-                    onClick={() => alert('Settings placeholder')}
+                    onClick={handleSettingsClicked}
                     className="inline-flex justify-center items-center p-2 rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
                 >
                     <AdjustmentsVerticalIcon className="h-5 w-5 text-white" />
                 </button>
                 <button
-                    onClick={() => alert('Chat mode placeholder')}
+                    onClick={handleChatModeClicked}
                     className="inline-flex justify-center items-center p-2 rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white ml-2"
                 >
                     <ChatBubbleLeftRightIcon className="h-5 w-5 text-white" />

--- a/src/windows/chat/main.tsx
+++ b/src/windows/chat/main.tsx
@@ -1,0 +1,26 @@
+import React, {useEffect} from "react";
+import ReactDOM from "react-dom/client";
+import "../../styles.css";
+
+const Chat = () => {
+    async function setupAppWindow() {
+        const appWindow = (await import('@tauri-apps/api/window')).appWindow
+        await appWindow.show();
+    }
+
+    useEffect(() => {
+        setupAppWindow()
+    }, [])
+
+    return (
+        <div>
+            <h1>Chat Window</h1>
+        </div>
+    )
+}
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+        <Chat/>
+    </React.StrictMode>,
+);

--- a/src/windows/settings/main.tsx
+++ b/src/windows/settings/main.tsx
@@ -1,0 +1,26 @@
+import React, {useEffect} from "react";
+import ReactDOM from "react-dom/client";
+import "../../styles.css";
+
+const Settings = () => {
+    async function setupAppWindow() {
+        const appWindow = (await import('@tauri-apps/api/window')).appWindow
+        await appWindow.show();
+    }
+
+    useEffect(() => {
+        setupAppWindow()
+    }, [])
+
+    return (
+        <div>
+            <h1>Settings Window</h1>
+        </div>
+    )
+}
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+        <Settings/>
+    </React.StrictMode>,
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-    content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+    content: ["./index.html", "./chat.html", "./settings.html", "./src/**/*.{js,ts,jsx,tsx}"],
     theme: {
         extend: {
             fontFamily: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { resolve } from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
@@ -17,4 +18,13 @@ export default defineConfig(async () => ({
   // 3. to make use of `TAURI_DEBUG` and other env variables
   // https://tauri.app/v1/api/config#buildconfig.beforedevcommand
   envPrefix: ["VITE_", "TAURI_"],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        chat: resolve(__dirname, 'chat.html'),
+        settings: resolve(__dirname, 'settings.html')
+      }
+    }
+  }
 }));


### PR DESCRIPTION
When you click on the settings and chat icons in the spotlight window toolbar you now open a blank placeholder window for the settings dialog and chat view respectively.

On first creation, windows are initially hidden and then client side `useEffect` hook triggers the window to be shown. This avoids the flashing effect as it takes a few milliseconds for the content to render.

Refer to: https://github.com/tauri-apps/tauri/issues/5170#issuecomment-1413240362

We now have separate bundles for each of the three windows. We may want to move the spotlight window code around to align it with the location of the other windows' code. Can do as part of implementing those windows.