### PR TITLE
:recycle: Fix get models

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,14 +5,24 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use tauri::command;
 use thiserror::Error;
-// Import the command macro for Tauri.
-use serde::ser::Error as SerdeError;
-use serde::Serialize; // Add this to bring the `Error` trait into scope.
+use serde::{Deserialize, Serialize}; // Add this to bring the `Error` trait into scope.
 use tauri::{Builder, Manager, WindowBuilder, WindowUrl};
 
 #[derive(Debug, Serialize)]
 struct ModelList {
     models: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Model {
+    name: String,
+    modified_at: String,
+    size: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ModelsResponse {
+    models: Vec<Model>,
 }
 
 #[derive(Debug, Error)]
@@ -65,30 +75,23 @@ async fn askollama(question: String, models: String) -> Result<String, ApiError>
     Ok(final_response)
 }
 
-/// Retrieves the list of models from Ollama API
+/// Retrieves the list of models from Ollama API/// Retrieves the list of models from Ollama API
 #[command]
-fn get_ollama_models() -> Result<ModelList, ApiError> {
-    let output = std::process::Command::new("ollama")
-        .arg("list")
-        .output()
-        .map_err(|e| ApiError::CommandError(e.to_string()))?;
+async fn get_ollama_models() -> Result<ModelList, ApiError> {
+    let url = "http://localhost:11434/api/tags";
+    let client = Client::new();
+    let models_response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(ApiError::Network)?
+        .json::<ModelsResponse>()
+        .await
+        .map_err(ApiError::Network)?; // Change this line
 
-    if !output.status.success() {
-        let error_message = String::from_utf8_lossy(&output.stderr).into_owned();
-        return Err(ApiError::CommandError(error_message));
-    }
+    let model_names = models_response.models.into_iter().map(|model| model.name).collect();
 
-    let models = String::from_utf8(output.stdout)
-        .map_err(|_| {
-            ApiError::ParseError(serde_json::error::Error::custom("Invalid UTF-8 sequence"))
-        })?
-        .lines()
-        // Skip the first line, which is the header
-        .skip(1)
-        .filter_map(|line| line.split_whitespace().next().map(ToString::to_string))
-        .collect();
-
-    Ok(ModelList { models })
+    Ok(ModelList { models: model_names })
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,11 +2,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use reqwest::Client;
+use serde::{Deserialize, Serialize}; // Add this to bring the `Error` trait into scope.
 use serde_json::{json, Value};
 use tauri::command;
-use thiserror::Error;
-use serde::{Deserialize, Serialize}; // Add this to bring the `Error` trait into scope.
 use tauri::{Builder, Manager, WindowBuilder, WindowUrl};
+use thiserror::Error;
 
 #[derive(Debug, Serialize)]
 struct ModelList {
@@ -89,9 +89,15 @@ async fn get_ollama_models() -> Result<ModelList, ApiError> {
         .await
         .map_err(ApiError::Network)?; // Change this line
 
-    let model_names = models_response.models.into_iter().map(|model| model.name).collect();
+    let model_names = models_response
+        .models
+        .into_iter()
+        .map(|model| model.name)
+        .collect();
 
-    Ok(ModelList { models: model_names })
+    Ok(ModelList {
+        models: model_names,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -75,7 +75,7 @@ async fn askollama(question: String, models: String) -> Result<String, ApiError>
     Ok(final_response)
 }
 
-/// Retrieves the list of models from Ollama API/// Retrieves the list of models from Ollama API
+/// Retrieves the list of models from Ollama API
 #[command]
 async fn get_ollama_models() -> Result<ModelList, ApiError> {
     let url = "http://localhost:11434/api/tags";


### PR DESCRIPTION
use api not cli for the get models function; will improve stability and compatibility across all platforms

<!--
Please include a summary of the change and which issue is fixed along with any relevant motivation, context and any dependencies that are required for this change along with any breaking changes that may be introduced.
-->
